### PR TITLE
fix(emoji-blast): allow partial initialVelocities in emojiBlast

### DIFF
--- a/packages/emoji-blast/src/emojiBlast.ts
+++ b/packages/emoji-blast/src/emojiBlast.ts
@@ -8,7 +8,7 @@ import { animate } from "./animate.js";
 import { defaultEmojis } from "./emojis.js";
 import { EmojiEvents, initializeEvents } from "./events.js";
 import { createStyleElementAndClass } from "./styles.js";
-import { obtainValue, shuffleArray } from "./utils.js";
+import { MakePartial, obtainValue, shuffleArray } from "./utils.js";
 
 /**
  * Settings to launch a blast of emojis! 🎆
@@ -42,7 +42,7 @@ export interface EmojiBlastSettings {
 	/**
 	 * Runtime change constants for emoji element movements.
 	 */
-	physics: Partial<EmojiPhysics>;
+	physics: MakePartial<EmojiPhysics, "initialVelocities">;
 
 	/**
 	 * How to determine where to place blasts of emojis around the page.

--- a/packages/emoji-blast/src/utils.ts
+++ b/packages/emoji-blast/src/utils.ts
@@ -1,3 +1,8 @@
+export type MakePartial<T, PartialKeys extends keyof T> = Partial<
+	Omit<T, PartialKeys>
+> & {
+	[K in PartialKeys]?: Partial<T[K]>;
+};
 /**
  * Grabs the value of an item or item-returning function.
  * @param value   Item or item-returning function.

--- a/packages/emoji-blast/src/utils.ts
+++ b/packages/emoji-blast/src/utils.ts
@@ -1,3 +1,6 @@
+/**
+ * Like Partial, but also makes particular properties Partial one level deep.
+ */
 export type MakePartial<T, PartialKeys extends keyof T> = Partial<
 	Omit<T, PartialKeys>
 > & {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #286
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a new `MakePartial` utility so that `initialVelocities` in `settings.physics` is also `Partial`. 