### PR TITLE
fix(emoji-blast-site): fix mobile viewport

### DIFF
--- a/packages/emoji-blast-site/src/components/footer/styles.tsx
+++ b/packages/emoji-blast-site/src/components/footer/styles.tsx
@@ -14,7 +14,7 @@ export const contentContainer = {
 	display: "flex",
 	justifyContent: "flex-end",
 
-	margin: "0rem 2.5rem 0rem 0rem",
+	margin: "0rem 2.5rem 0rem",
 };
 
 export const icon = {

--- a/packages/emoji-blast-site/src/components/usage-container/styles.tsx
+++ b/packages/emoji-blast-site/src/components/usage-container/styles.tsx
@@ -5,7 +5,7 @@ export const usageContainer = {
 		padding: "1rem 2rem 1rem 2rem",
 	},
 	"@media (max-width: 1180px)": {
-		padding: "3rem 10rem 5rem 10rem",
+		padding: "3rem min(10rem, 5vw) 5rem",
 	},
 	alignItems: "space-between",
 	backgroundColor: colors.violet200,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #307
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies a couple of small touchups to get mobile viewports padded appropriately.