### PR TITLE
fix(emoji-blast-site): correct zero-coords for hero button kbd click

### DIFF
--- a/packages/emoji-blast-site/src/components/hero/hero.tsx
+++ b/packages/emoji-blast-site/src/components/hero/hero.tsx
@@ -11,6 +11,21 @@ import * as styles from "./styles";
 export function Hero() {
 	useKonamiEmojiBlast();
 
+	const onExplosion: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+		let x, y;
+
+		if (e.clientX === 0 && e.clientY === 0) {
+			const rect = e.currentTarget.getBoundingClientRect();
+			x = rect.x + rect.width / 2;
+			y = rect.y + rect.height / 2;
+		} else {
+			x = e.clientX;
+			y = e.clientY;
+		}
+
+		emojiBlast({ position: { x, y } });
+	};
+
 	return (
 		<div css={styles.heroContainer}>
 			<Title addStyles={styles.title} />
@@ -24,18 +39,7 @@ export function Hero() {
 				>
 					GitHub
 				</Anchor>
-				<Button
-					explosionFunction={(event) => {
-						emojiBlast({
-							position: {
-								x: event.clientX,
-								y: event.clientY,
-							},
-						});
-					}}
-				>
-					Click Me
-				</Button>
+				<Button explosionFunction={onExplosion}>Click Me</Button>
 			</div>
 		</div>
 	);


### PR DESCRIPTION


<!-- 👋 Hi, thanks for sending a PR to emoji-blast! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #315
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This adds the correction for zero coordinates for when the hero button is clicked through the keyboard press (Enter key). There is no proper way to detect when the "click" MouseEvent is triggered by the keyboard, despite handling the zero coords, which also not always zero (Safari should set them to the center of the clicked element (for keyboard "clicks")).

