### PR TITLE
fix: correct peerDependency behavior and global/now script for astro

### DIFF
--- a/packages/konami-emoji-blast-astro/README.md
+++ b/packages/konami-emoji-blast-astro/README.md
@@ -18,10 +18,10 @@
 
 ## Usage
 
-First install the `@konami-emoji-blast/astro` package as a dependency:
+First install the `@konami-emoji-blast/astro` and `konami-emoji-blast` packages as dependencies:
 
 ```shell
-npm i @konami-emoji-blast/astro
+npm i @konami-emoji-blast/astro konami-emoji-blast
 ```
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:

--- a/packages/konami-emoji-blast-astro/package.json
+++ b/packages/konami-emoji-blast-astro/package.json
@@ -22,13 +22,11 @@
 	"type": "module",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
-	"dependencies": {
-		"konami-emoji-blast": "workspace:"
-	},
 	"devDependencies": {
 		"astro": "^4.0.0"
 	},
 	"peerDependencies": {
-		"astro": "^2 || ^3 || ^4"
+		"astro": "^2 || ^3 || ^4",
+		"konami-emoji-blast": "workspace:"
 	}
 }

--- a/packages/konami-emoji-blast-astro/src/index.ts
+++ b/packages/konami-emoji-blast-astro/src/index.ts
@@ -4,7 +4,7 @@ export function konamiEmojiBlast(): AstroIntegration {
 	return {
 		hooks: {
 			"astro:config:setup"({ injectScript }) {
-				injectScript("page", `import "konami-emoji-blast/dist/global.js";`);
+				injectScript("page", `import "konami-emoji-blast/dist/now.js";`);
 			},
 		},
 		name: "@konami-emoji-blast/astro",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #385
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies two fixes while I'm in the area:

* Switches the dependency and instructions to act as a peer dependency, to ensure it's in the root `node_modules/`
* Switches from `global.js` -which just sets up a global JS function- to `now.js`