### PR TITLE
fix: add missing build:release(:all) script for Nuxt builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: pnpm build:all
+      - run: pnpm build:release:all
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"scripts": {
 		"build": "pnpm run -r prebuild; tsc -b",
 		"build:all": "pnpm run -r prebuild; pnpm run -F \\!root -r build",
+		"build:release:all": "pnpm run -r build:release",
 		"format": "prettier .",
 		"format:write": "pnpm format --write",
 		"lint": "eslint . .*js --max-warnings 0",

--- a/packages/konami-emoji-blast-nuxt/.github/DEVELOPMENT.md
+++ b/packages/konami-emoji-blast-nuxt/.github/DEVELOPMENT.md
@@ -12,10 +12,10 @@ pnpm dev
 
 ...then visit <localhost:30000> in your browser.
 
-## Building
+## Building for Release
 
-Run `pnpm dev:prepare` to build source files into the `dist/` folder:
+Run `pnpm build:release` to build source files into the `dist/` folder:
 
 ```shell
-pnpm dev:prepare
+pnpm build:release
 ```

--- a/packages/konami-emoji-blast-nuxt/package.json
+++ b/packages/konami-emoji-blast-nuxt/package.json
@@ -35,9 +35,9 @@
 	"scripts": {
 		"prebuild": "nuxi prepare",
 		"build": "nuxi build",
+		"build:release": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
 		"dev": "nuxi dev playground",
 		"dev:build": "nuxi build playground",
-		"dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
 		"lint": "eslint .",
 		"test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
 	},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #822
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`nuxt-module-build build` is the script that actually populates the `dist/` directory. It wasn't being run or documented to be run before releases.

💖 