### PR TITLE
docs: note temporary konami-code-js Vite optimizeDeps workaround

### DIFF
--- a/packages/emoji-blast-site/src/content/docs/integrations/Nuxt.mdx
+++ b/packages/emoji-blast-site/src/content/docs/integrations/Nuxt.mdx
@@ -15,6 +15,13 @@ You can then use the `"@konami-emoji-blast/nuxt"` plugin in your `nuxt.config.*`
 ```ts
 export default defineNuxtConfig({
 	modules: ["@konami-emoji-blast/nuxt"],
+
+	// Temporary workaround for https://github.com/JoshuaKGoldberg/emoji-blast/issues/822:
+	vite: {
+		optimizeDeps: {
+			include: ["konami-emoji-blast > konami-code-js"],
+		},
+	},
 });
 ```
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #822 (finally!)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Notes the workaround needed while `konami-code-js` can't be run in ESM mode, per https://github.com/JoshuaKGoldberg/emoji-blast/issues/822#issuecomment-2532958348.