### PR TITLE
docs: switch homepage check from slug to pathname

### DIFF
--- a/packages/emoji-blast-site/src/components/TwoColumnContent.astro
+++ b/packages/emoji-blast-site/src/components/TwoColumnContent.astro
@@ -5,8 +5,6 @@ import Default from "@astrojs/starlight/components/TwoColumnContent.astro";
 import Hero from "./Hero.astro";
 ---
 
-{JSON.stringify([Astro.props.slug])}
-
 {
 	Astro.props.slug ? (
 		<Default {...Astro.props}>

--- a/packages/emoji-blast-site/src/components/TwoColumnContent.astro
+++ b/packages/emoji-blast-site/src/components/TwoColumnContent.astro
@@ -6,7 +6,7 @@ import Hero from "./Hero.astro";
 ---
 
 {
-	Astro.props.slug ? (
+	Astro.url.pathname.length > 1 ? (
 		<Default {...Astro.props}>
 			<slot />
 			<slot name="right-sidebar" slot="right-sidebar" />

--- a/packages/emoji-blast-site/src/components/TwoColumnContent.astro
+++ b/packages/emoji-blast-site/src/components/TwoColumnContent.astro
@@ -5,13 +5,15 @@ import Default from "@astrojs/starlight/components/TwoColumnContent.astro";
 import Hero from "./Hero.astro";
 ---
 
+{JSON.stringify([Astro.props.slug])}
+
 {
-	Astro.props.slug === "" ? (
-		<Hero />
-	) : (
+	Astro.props.slug ? (
 		<Default {...Astro.props}>
 			<slot />
 			<slot name="right-sidebar" slot="right-sidebar" />
 		</Default>
+	) : (
+		<Hero />
 	)
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #978
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`Astro.props.slug` is deprecated. `Astro.url.pathname` does roughly what I was looking for anyway.

💖 