### PR TITLE
fix(konami-emoji-blast-nuxt): remove CJS dist references

### DIFF
--- a/.changeset/lemon-bobcats-melt.md
+++ b/.changeset/lemon-bobcats-melt.md
@@ -1,0 +1,5 @@
+---
+"@konami-emoji-blast/nuxt": minor
+---
+
+Remove now-unnecessary CJS exports

--- a/packages/konami-emoji-blast-nuxt/package.json
+++ b/packages/konami-emoji-blast-nuxt/package.json
@@ -22,13 +22,10 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"types": "./dist/types.d.ts",
-			"import": "./dist/module.mjs",
-			"require": "./dist/module.cjs"
+			"types": "./dist/types.d.mts",
+			"import": "./dist/module.mjs"
 		}
 	},
-	"main": "./dist/module.cjs",
-	"types": "./dist/types.d.ts",
 	"files": [
 		"dist"
 	],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1500
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

As the error messages said, `@nuxt/module-builder` no longer generates CJS files. It produces ESM-only.

I'm going to consider this a `fix` since all the supported Node.js versions support require(esm). But just to be safe, the changeset marks it as a minor-level version change (not patch).

💖