### PR TITLE
fix(site): js strict mode added by sucrase breaks playground code eval

### DIFF
--- a/packages/site/src/utils/runPlaygroundCode.ts
+++ b/packages/site/src/utils/runPlaygroundCode.ts
@@ -38,7 +38,7 @@ export const runPlaygroundCode = (code: string) => {
 	const executableModule = new Function(
 		"require",
 		...FORBIDDEN_GLOBALS,
-		transpiledCode,
+		transpiledCode.replace(/^["']use strict["'];?\s*/, ""),
 	);
 
 	const mockRequire = (moduleName: string) => {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to emoji-blast! 🎆
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes this issue when trying to "Run Code" on playground with a one-line regex.

<img width="388" height="170" alt="Console error of playground when running code" src="https://github.com/user-attachments/assets/b6a78a7d-760a-4775-bb98-83606ae05da6" />

😵‍💫