### PR TITLE
chore: dynamically import emoji-blast version in PlaygroundEditor

### DIFF
--- a/packages/site/src/components/PlaygroundEditor.tsx
+++ b/packages/site/src/components/PlaygroundEditor.tsx
@@ -1,5 +1,6 @@
 import Editor, { type Monaco } from "@monaco-editor/react";
 import emojiBlastTypeSource from "emoji-blast/lib/emojiBlast.d.ts?raw";
+import { version } from "emoji-blast/package.json";
 import { useState } from "react";
 import { useStarlightTheme } from "use-starlight-theme";
 
@@ -8,8 +9,8 @@ import { runPlaygroundCode } from "~/utils/runPlaygroundCode";
 import { Button } from "./Button";
 
 const EMOJI_BLAST_PACKAGE_METADATA = {
-	url: "https://www.npmjs.com/package/emoji-blast/v/0.11.0",
-	version: "v0.11.0",
+	url: `https://www.npmjs.com/package/emoji-blast/v/${version}`,
+	version: `v${version}`,
 };
 
 const DEFAULT_EDITOR_CONTENT = `import { emojiBlast } from "emoji-blast";


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to emoji-blast! 🎆
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1532
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/emoji-blast/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/emoji-blast/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Replaced the hardcoded `EMOJI_BLAST_PACKAGE_METADATA` in `PlaygroundEditor.tsx`
with the version read from `packages/emoji-blast/package.json` at build time,
and derived the npm URL from that version.

### Alternatives considered

**`import { version } from "emoji-blast/package.json" with { type: "json" }`.**
Import attributes are only available from Node 18.20.0, 20.10.0 and 21.0.0
onwards, but `packages/emoji-blast/package.json` declares `"node": ">=18"`,
which still allows 18.0–18.19. So this would break on supported versions.

**Reading the value in `packages/emoji-blast/webpack.config.js`.**
Routing build config through to a single site component felt like too much
machinery for one constant.

<!-- Description of what is changed and how the code change does that. -->
